### PR TITLE
Cmake cppstd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ message(STATUS "  Version: ${ROOT_VERSION}")
 message(STATUS "  ROOT executable: ${ROOT_EXECUTABLE}")
 message(STATUS "  Include directories: ${ROOT_INCLUDE_DIRS}")
 message(STATUS "  Compiler flags: ${ROOT_CXX_FLAGS}")
+message(STATUS "")
 
 # Register analysis executable target
 add_executable(Analysis analysis.cxx)
@@ -30,11 +31,27 @@ target_link_libraries(Analysis ROOT::ROOTVecOps ROOT::ROOTDataFrame)
 # the verbose make output with "VERBOSE=1 make".
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ROOT_CXX_FLAGS}")
 
-# Use -fconcepts with g++ to silcence following warning:
+# Use -fconcepts with g++ to silence following warning:
 # warning: use of 'auto' in parameter declaration only available with '-fconcepts
 if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    message(STATUS "Attach -fconcepts to the compiler flags to silence warnings.")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts")
 endif()
+
+# Find the C++ standard from ROOT and set it as the standard of this project
+# We require the C++ standard 17 or 20.
+if (${ROOT_CXX_FLAGS} MATCHES "\\-std\\=c\\+\\+17")
+    message(STATUS "Set c++17 as the C++ standard.")
+    set(CMAKE_CXX_STANDARD 17)
+elseif (${ROOT_CXX_FLAGS} MATCHES "\\-std\\=c\\+\\+20")
+    message(STATUS "Set c++20 as the C++ standard.")
+    set(CMAKE_CXX_STANDARD 20)
+else ()
+    message(FATAL_ERROR "The standard c++17 or higher is required but not found in the ROOT flags: ${ROOT_CXX_FLAGS}")
+endif()
+
+# Build the logging library
+# TODO
 
 # Print settings of the executable
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
 endif()
 
 # Find the C++ standard from ROOT and set it as the standard of this project
-# We require the C++ standard 17 or 20.
+# We require the C++ standard 17 or 20 and don't want to fall back to lower versions.
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (${ROOT_CXX_FLAGS} MATCHES "\\-std\\=c\\+\\+17")
     message(STATUS "Set c++17 as the C++ standard.")
     set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Das hier enforced, dass ihr auch den C++ standard von root verwendet. Zudem verhindert `CMAKE_CXX_STANDARD_REQUIRED`, dass ihr implizit ueber einen fallback zu einem niedrigeren standard fallt. Das kann zB passieren, wenn ihr mit gcc 4.8.5 baut.