### PR TITLE
python backbone

### DIFF
--- a/analysis.cxx
+++ b/analysis.cxx
@@ -78,8 +78,10 @@ int main() {
     auto df24_2 =
         physicsobject::FilterObjects(df24_1, "nMuon", 1, "NumberOfMuons");
     auto mt_df = pairselection::mutau::PairSelection(
-        df24_2, {"Tau_pt", "Tau_rawDeepTau2017v2p1VSjet", "Muon_pt",
-                          "Muon_pfRelIso04_all", "good_taus_mask", "good_muons_mask"}, "mtpair");
+        df24_2,
+        {"Tau_pt", "Tau_rawDeepTau2017v2p1VSjet", "Muon_pt",
+         "Muon_pfRelIso04_all", "good_taus_mask", "good_muons_mask"},
+        "mtpair");
     auto mt_df_1 =
         pairselection::filterGoodPairs(mt_df, "mtpair", "GoodMuTauPairs");
     auto mt_df_2 = lorentzvectors::mutau::build(
@@ -91,7 +93,8 @@ int main() {
     auto mt_df_6 = quantities::eta(mt_df_5, varSet, "eta_2", "p4_2");
     auto mt_df_7 = quantities::phi(mt_df_6, varSet, "phi_1", "p4_1");
     auto mt_df_8 = quantities::phi(mt_df_7, varSet, "phi_2", "p4_2");
-    auto mt_df_9 = quantities::m_vis(mt_df_8, varSet, "m_vis", {"p4_1", "p4_2"});
+    auto mt_df_9 =
+        quantities::m_vis(mt_df_8, varSet, "m_vis", {"p4_1", "p4_2"});
 
     auto df_final = mt_df_9;
     auto cutReport = df_final.Report();

--- a/analysis.cxx
+++ b/analysis.cxx
@@ -78,7 +78,8 @@ int main() {
     auto df24_2 =
         physicsobject::FilterObjects(df24_1, "nMuon", 1, "NumberOfMuons");
     auto mt_df = pairselection::mutau::PairSelection(
-        df24_2, "good_taus_mask", "good_muons_mask", "mtpair", {""});
+        df24_2, {"Tau_pt", "Tau_rawDeepTau2017v2p1VSjet", "Muon_pt",
+                          "Muon_pfRelIso04_all", "good_taus_mask", "good_muons_mask"}, "mtpair");
     auto mt_df_1 =
         pairselection::filterGoodPairs(mt_df, "mtpair", "GoodMuTauPairs");
     auto mt_df_2 = lorentzvectors::mutau::build(
@@ -90,7 +91,7 @@ int main() {
     auto mt_df_6 = quantities::eta(mt_df_5, varSet, "eta_2", "p4_2");
     auto mt_df_7 = quantities::phi(mt_df_6, varSet, "phi_1", "p4_1");
     auto mt_df_8 = quantities::phi(mt_df_7, varSet, "phi_2", "p4_2");
-    auto mt_df_9 = quantities::m_vis(mt_df_8, varSet, "m_vis", "p4_1", "p4_2");
+    auto mt_df_9 = quantities::m_vis(mt_df_8, varSet, "m_vis", {"p4_1", "p4_2"});
 
     auto df_final = mt_df_9;
     auto cutReport = df_final.Report();

--- a/analysis_template.cxx
+++ b/analysis_template.cxx
@@ -5,6 +5,7 @@
 #include "metfilter.hxx"
 #include "pairselection.hxx"
 #include "physicsobjects.hxx"
+#include "quantities.hxx"
 #include "utility/Logger.hxx"
 #include <ROOT/RLogger.hxx>
 #include <string>

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -2,6 +2,15 @@ import code_generation.producer as p
 
 
 def fill_template(t, config):
+    #shift producers
+    for shift in config.keys():
+        #shift names start with "_"
+        if not shift.startswith("_"):
+            continue
+        for entry in config[shift]["shiftbase"]:
+            getattr(p, entry).shift(shift)
+
+    #generate list of commands
     commandlist = "" #string to be placed into code template
     df_count = 0 #enumerate dataframes
 

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -2,8 +2,10 @@ import code_generation.producer as p
 
 
 def fill_template(t, config):
-    commandlist = ""
-    df_count = 0
+    commandlist = "" #string to be placed into code template
+    df_count = 0 #enumerate dataframes
+
+    #get commands of producers and append to the command list
     for producer in config["producers"]:
         for call in getattr(p, producer).writecalls(config):
             # print(call)
@@ -14,8 +16,4 @@ def fill_template(t, config):
             )
             df_count += 1
     commandlist += "  auto df_final = df%i;" % df_count
-    final = {}
-    final["CODE_GENERATION"] = commandlist
-    t = t.replace("  // {CODE_GENERATION}", commandlist)
-    # print(t)
-    return t
+    return t.replace("  // {CODE_GENERATION}", commandlist)

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -16,13 +16,14 @@ def fill_template(t, config):
 
     # get commands of producers and append to the command list
     for producer in config["producers"]:
+        commandlist += "\n    //" + producer + "\n"
         for call in getattr(p, producer).writecalls(config):
             # print(call)
             commandlist += (
-                "  auto df%i = " % (df_count + 1)
+                "    auto df%i = " % (df_count + 1)
                 + call.format_map(p.SafeDict({"df": "df%i" % df_count}))
                 + ";\n"
             )
             df_count += 1
-    commandlist += "  auto df_final = df%i;" % df_count
-    return t.replace("  // {CODE_GENERATION}", commandlist)
+    commandlist += "    auto df_final = df%i;" % df_count
+    return t.replace("    // {CODE_GENERATION}", commandlist)

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -11,7 +11,7 @@ def fill_template(t, config):
             # print(call)
             commandlist += (
                 "  auto df%i = " % (df_count + 1)
-                + call.format_map({"df": "df%i" % df_count})
+                + call.format_map(p.SafeDict({"df": "df%i" % df_count}))
                 + ";\n"
             )
             df_count += 1

--- a/code_generation/code_generation.py
+++ b/code_generation/code_generation.py
@@ -2,19 +2,19 @@ import code_generation.producer as p
 
 
 def fill_template(t, config):
-    #shift producers
+    # shift producers
     for shift in config.keys():
-        #shift names start with "_"
+        # shift names start with "_"
         if not shift.startswith("_"):
             continue
         for entry in config[shift]["shiftbase"]:
             getattr(p, entry).shift(shift)
 
-    #generate list of commands
-    commandlist = "" #string to be placed into code template
-    df_count = 0 #enumerate dataframes
+    # generate list of commands
+    commandlist = ""  # string to be placed into code template
+    df_count = 0  # enumerate dataframes
 
-    #get commands of producers and append to the command list
+    # get commands of producers and append to the command list
     for producer in config["producers"]:
         for call in getattr(p, producer).writecalls(config):
             # print(call)

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -260,6 +260,6 @@ UnrollLV1 = ProducerGroup(None, None, None, [pt_1, eta_1, phi_1])
 UnrollLV2 = ProducerGroup(None, None, None, [pt_2, eta_2, phi_2])
 
 m_vis = Producer(
-    'quantities::pt({df}, varSet, "{output}", {input_coll})', [q.p4_1, q.p4_2], q.m_vis
+    'quantities::m_vis({df}, varSet, "{output}", {input_coll})', [q.p4_1, q.p4_2], q.m_vis
 )
 DiTauPairQuantities = ProducerGroup(None, None, None, [UnrollLV1, UnrollLV2, m_vis])

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -17,13 +17,17 @@ class Producer:
             q.children.append(self.output)
 
     def shift(self, name):
-        self.output.shift(
-            name
-        )  # crashes on purpose if output is None. This method should not be called for a producer without output
+        if isinstance(self.output, list):
+            for entry in self.output:
+                entry.shift(name)
+        else:
+            self.output.shift(
+                name
+            )  # crashes on purpose if output is None. This method should not be called for a producer without output
 
     def writecall(self, config, shift=""):
         config[shift]["output"] = (
-            "" if self.output == None else self.output.get_leaf(shift)
+            "" if self.output == None else '{"' + '","'.join([x.get_leaf(shift) for x in self.output]) + '"}' if isinstance(self.output, list) else self.output.get_leaf(shift)
         )
         config[shift]["input"] = ",".join([x.get_leaf(shift) for x in self.inputs])
         config[shift]["input_coll"] = (
@@ -37,15 +41,16 @@ class Producer:
     def writecalls(self, config):
         calls = [self.writecall(config)]
         if self.output != None:
-            for shift in self.output.shifts:
+            list_of_shifts = self.output[0].shifts if isinstance(self.output, list) else self.output.shifts #all entries must have same shifts
+            for shift in list_of_shifts:
                 calls.append(self.writecall(config, shift))
         return calls
 
 
 class VectorProducer(Producer):
-    def __init__(self, call, inputs, output, vec_config):
+    def __init__(self, call, inputs, output, vec_configs):
         super().__init__(call, inputs, output)
-        self.vec_config = vec_config
+        self.vec_configs = vec_configs
 
     def writecalls(self, config):
         basecall = self.call
@@ -54,8 +59,21 @@ class VectorProducer(Producer):
         if self.output != None:
             shifts.extend(self.output.shifts)
         for shift in shifts:
-            for val in config[shift][self.vec_config]:
-                self.call = basecall.format_map(SafeDict({self.vec_config: val}))
+            #check that all config lists (and output if applicable) have same length
+            l = len(config[shift][self.vec_configs[0]])
+            for key in self.vec_configs:
+                if l!=len(config[shift][key]):
+                    print("Following lists in config must have same length: %s, %s"%(self.vec_configs[0], key))
+                    raise Exception
+            if self.output!=None and len(self.output)!=l:
+                    print("VectorProducer expects either no output or same amount as entries in config lists (e.g. %s)!"%self.vec_configs[0])
+            for i in range(l):
+                helper_dict = {}
+                for key in self.vec_configs:
+                    helper_dict[key] = config[shift][key][i]
+                if self.output!=None:
+                    helper_dict["output"] = self.output[i]
+                self.call = basecall.format_map(SafeDict(helper_dict))
                 calls.append(self.writecall(config, shift))
         self.call = basecall
         return calls
@@ -79,5 +97,5 @@ MetFilter = VectorProducer(
     'metfilter::ApplyMetFilter({df}, "{met_filters}", "{met_filters}")',
     [],
     None,
-    "met_filters",
+    ["met_filters"],
 )

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -146,20 +146,6 @@ class ProducerGroup:
         return calls
 
 
-prod1 = Producer(
-    "phyticsd::FilterID(auto {df}, const std::string {output}, std::string isolationName)",
-    [],
-    q.pt_1,
-)
-prod2 = Producer(
-    "FilterID(auto {df}, const std::string {output}, std::string isolationName)",
-    [],
-    q.pt_2,
-)
-prod3 = Producer(
-    'FilterID({df}, "{output}", {input_coll}, {ptcut})', [q.pt_1, q.pt_2], q.m_vis
-)
-
 MetFilter = VectorProducer(
     'metfilter::ApplyMetFilter({df}, "{met_filters}", "{met_filters}")',
     [],

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -103,16 +103,16 @@ class ProducerGroup:
         self.producers = subproducers
         # link producers
         for p in self.producers:
+            # check that output quantities of subproducers are not yet filled
+            if p.output != None:
+                print("Output of subproducers must be None!") 
+                raise Exception 
             # skip producers without output
             if not "output" in p.call:
                 continue
-            # check that output quantities of subproducers are not yet filled
-            if p.output != None:
-                print("Output of subproducers must be None!")
-                raise Exception
             # create quantities that are produced by subproducers and then collected by the final call of the producer group
             p.output = q.Quantity(
-                "PG_internal_quantity%i" % self.__class__.PG_count
+                "PG_internal_quantity_%i" % self.__class__.PG_count
             )  # quantities of vector producers will be duplicated later on when config is known
             self.__class__.PG_count += 1
             self.inputs.append(p.output)
@@ -132,7 +132,7 @@ class ProducerGroup:
                 for i in range(len(config[""][producer.vec_configs[0]]) - 1):
                     producer.output.append(
                         producer.output[0].copy(
-                            "PG_internal_quantity%i" % self.__class__.PG_count
+                            "PG_internal_quantity_%i" % self.__class__.PG_count
                         )
                     )
                     self.__class__.PG_count += 1

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -1,5 +1,6 @@
 import code_generation.quantities as q
 
+
 class SafeDict(dict):
     def __missing__(self, key):
         return "{" + key + "}"
@@ -26,7 +27,11 @@ class Producer:
 
     def writecall(self, config, shift=""):
         config[shift]["output"] = (
-            "" if self.output == None else '{"' + '","'.join([x.get_leaf(shift) for x in self.output]) + '"}' if isinstance(self.output, list) else self.output.get_leaf(shift)
+            ""
+            if self.output == None
+            else '{"' + '","'.join([x.get_leaf(shift) for x in self.output]) + '"}'
+            if isinstance(self.output, list)
+            else self.output.get_leaf(shift)
         )
         config[shift]["input"] = ",".join([x.get_leaf(shift) for x in self.inputs])
         config[shift]["input_coll"] = (
@@ -40,7 +45,11 @@ class Producer:
     def writecalls(self, config):
         calls = [self.writecall(config)]
         if self.output != None:
-            list_of_shifts = self.output[0].shifts if isinstance(self.output, list) else self.output.shifts #all entries must have same shifts
+            list_of_shifts = (
+                self.output[0].shifts
+                if isinstance(self.output, list)
+                else self.output.shifts
+            )  # all entries must have same shifts
             for shift in list_of_shifts:
                 calls.append(self.writecall(config, shift))
         return calls
@@ -58,47 +67,56 @@ class VectorProducer(Producer):
         if self.output != None:
             shifts.extend(self.output[0].shifts)
         for shift in shifts:
-            #check that all config lists (and output if applicable) have same length
+            # check that all config lists (and output if applicable) have same length
             l = len(config[shift][self.vec_configs[0]])
             for key in self.vec_configs:
-                if l!=len(config[shift][key]):
-                    print("Following lists in config must have same length: %s, %s"%(self.vec_configs[0], key))
+                if l != len(config[shift][key]):
+                    print(
+                        "Following lists in config must have same length: %s, %s"
+                        % (self.vec_configs[0], key)
+                    )
                     raise Exception
-            if self.output!=None and len(self.output)!=l:
-                    print("VectorProducer expects either no output or same amount as entries in config lists (e.g. %s)!"%self.vec_configs[0])
+            if self.output != None and len(self.output) != l:
+                print(
+                    "VectorProducer expects either no output or same amount as entries in config lists (e.g. %s)!"
+                    % self.vec_configs[0]
+                )
             for i in range(l):
                 helper_dict = {}
                 for key in self.vec_configs:
                     helper_dict[key] = config[shift][key][i]
-                if self.output!=None:
+                if self.output != None:
                     helper_dict["output"] = self.output[i].get_leaf(shift)
                 self.call = basecall.format_map(SafeDict(helper_dict))
                 calls.append(self.writecall(config, shift))
         self.call = basecall
         return calls
 
-class ProducerGroup():
-    PG_count = 1 #counter for internal quantities used by ProducerGroups
+
+class ProducerGroup:
+    PG_count = 1  # counter for internal quantities used by ProducerGroups
 
     def __init__(self, call, inputs, output, subproducers):
         self.call = call
         self.inputs = inputs
         self.output = output
         self.producers = subproducers
-        #link producers
+        # link producers
         for p in self.producers:
-            #skip producers without output
+            # skip producers without output
             if not "output" in p.call:
                 continue
-            #check that output quantities of subproducers are not yet filled
-            if p.output!=None:
+            # check that output quantities of subproducers are not yet filled
+            if p.output != None:
                 print("Output of subproducers must be None!")
                 raise Exception
-            #create quantities that are produced by subproducers and then collected by the final call of the producer group
-            p.output = q.Quantity("PG_internal_quantity%i"%self.__class__.PG_count) #quantities of vector producers will be duplicated later on when config is known
+            # create quantities that are produced by subproducers and then collected by the final call of the producer group
+            p.output = q.Quantity(
+                "PG_internal_quantity%i" % self.__class__.PG_count
+            )  # quantities of vector producers will be duplicated later on when config is known
             self.__class__.PG_count += 1
             self.inputs.append(p.output)
-        #treat own collection function as subproducer
+        # treat own collection function as subproducer
         self.producers.append(Producer(self.call, self.inputs, self.output))
 
     def shift(self, name):
@@ -108,14 +126,18 @@ class ProducerGroup():
     def writecalls(self, config):
         calls = []
         for producer in self.producers:
-            #duplicate outputs of vector subproducers
+            # duplicate outputs of vector subproducers
             if hasattr(producer, "vec_configs"):
                 producer.output = [producer.output]
                 for i in range(len(config[""][producer.vec_configs[0]]) - 1):
-                    producer.output.append(producer.output[0].copy("PG_internal_quantity%i"%self.__class__.PG_count))
+                    producer.output.append(
+                        producer.output[0].copy(
+                            "PG_internal_quantity%i" % self.__class__.PG_count
+                        )
+                    )
                     self.__class__.PG_count += 1
                     self.inputs.append(producer.output[-1])
-            #retrieve calls of subproducers
+            # retrieve calls of subproducers
             calls.extend(producer.writecalls(config))
         return calls
 
@@ -141,8 +163,58 @@ MetFilter = VectorProducer(
     ["met_filters"],
 )
 
-TauPtCut = Producer('physicsobject::CutPt({df}, "{input}", "{output}", {ptcut})', [q.Tau_pt], None)
-TauEtaCut = Producer('physicsobject::CutEta({df}, "{input}", "{output}", {etacut})', [q.Tau_eta], None)
-TauDzCut = Producer('physicsobject::CutDz({df}, "{input}", "{output}", {ptcut})', [q.Tau_dz], None)
-TauIDFilters = VectorProducer('physicsobject::tau::FilterTauID({df}, "{output}", "{tau_id}", {tau_id_idx})', [], None, ["tau_id", "tau_id_idx"])
-GoodTaus = ProducerGroup('physicsobject::CombineMasks({df}, "{output}", {input_coll})', [], q.good_taus_mask, [TauPtCut, TauEtaCut, TauDzCut, TauIDFilters])
+TauPtCut = Producer(
+    'physicsobject::CutPt({df}, "{input}", "{output}", {min_tau_pt})', [q.Tau_pt], None
+)
+TauEtaCut = Producer(
+    'physicsobject::CutEta({df}, "{input}", "{output}", {max_tau_eta})',
+    [q.Tau_eta],
+    None,
+)
+TauDzCut = Producer(
+    'physicsobject::CutDz({df}, "{input}", "{output}", {max_tau_dz})', [q.Tau_dz], None
+)
+TauIDFilters = VectorProducer(
+    'physicsobject::tau::FilterTauID({df}, "{output}", "{tau_id}", {tau_id_idx})',
+    [],
+    None,
+    ["tau_id", "tau_id_idx"],
+)
+GoodTaus = ProducerGroup(
+    'physicsobject::CombineMasks({df}, "{output}", {input_coll})',
+    [],
+    q.good_taus_mask,
+    [TauPtCut, TauEtaCut, TauDzCut, TauIDFilters],
+)
+
+MuonPtCut = Producer(
+    'physicsobject::CutPt({df}, "{input}", "{output}", {min_muon_pt})',
+    [q.Muon_pt],
+    None,
+)
+MuonEtaCut = Producer(
+    'physicsobject::CutEta({df}, "{input}", "{output}", {max_muon_eta})',
+    [q.Muon_eta],
+    None,
+)
+MuonIDFilter = Producer(
+    'physicsobject::muon::FilterID({df}, "{output}", "{muon_id}")', [], None
+)
+MuonIsoFilter = Producer(
+    'physicsobject::muon::FilterIsolation({df}, "{output}", "{muon_iso}", "{muon_iso_cut}")',
+    [],
+    None,
+)
+GoodMuons = ProducerGroup(
+    'physicsobject::CombineMasks({df}, "{output}", {input_coll})',
+    [],
+    q.good_muons_mask,
+    [MuonPtCut, MuonEtaCut, MuonIDFilter, MuonIsoFilter],
+)
+
+RequireObjects = VectorProducer(
+    'physicsobject::FilterObjects({df}, "{require_candidate}", {require_candidate_number}, "{require_candidate}")',
+    [],
+    None,
+    ["require_candidate", "require_candidate_number"],
+)

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -260,6 +260,8 @@ UnrollLV1 = ProducerGroup(None, None, None, [pt_1, eta_1, phi_1])
 UnrollLV2 = ProducerGroup(None, None, None, [pt_2, eta_2, phi_2])
 
 m_vis = Producer(
-    'quantities::m_vis({df}, varSet, "{output}", {input_coll})', [q.p4_1, q.p4_2], q.m_vis
+    'quantities::m_vis({df}, varSet, "{output}", {input_coll})',
+    [q.p4_1, q.p4_2],
+    q.m_vis,
 )
 DiTauPairQuantities = ProducerGroup(None, None, None, [UnrollLV1, UnrollLV2, m_vis])

--- a/code_generation/producer.py
+++ b/code_generation/producer.py
@@ -201,7 +201,7 @@ MuonIDFilter = Producer(
     'physicsobject::muon::FilterID({df}, "{output}", "{muon_id}")', [], None
 )
 MuonIsoFilter = Producer(
-    'physicsobject::muon::FilterIsolation({df}, "{output}", "{muon_iso}", "{muon_iso_cut}")',
+    'physicsobject::muon::FilterIsolation({df}, "{output}", "{muon_iso}", {muon_iso_cut})',
     [],
     None,
 )

--- a/code_generation/quantities.py
+++ b/code_generation/quantities.py
@@ -17,16 +17,22 @@ class Quantity:
                 c.shift(name)
 
     def copy(self, name):
-       copy = Quantity(name)
-       copy.shifts = self.shifts
-       copy.children = self.children
-       return copy
+        copy = Quantity(name)
+        copy.shifts = self.shifts
+        copy.children = self.children
+        return copy
+
 
 pt_1 = Quantity("pt_1")
 pt_2 = Quantity("pt_2")
 m_vis = Quantity("m_vis")
 mt_1 = Quantity("mt_1")
+
 good_taus_mask = Quantity("good_taus_mask")
 Tau_pt = Quantity("Tau_pt")
 Tau_eta = Quantity("Tau_eta")
 Tau_dz = Quantity("Tau_dz")
+
+good_muons_mask = Quantity("good_muons_mask")
+Muon_pt = Quantity("Muon_pt")
+Muon_eta = Quantity("Muon_eta")

--- a/code_generation/quantities.py
+++ b/code_generation/quantities.py
@@ -16,8 +16,17 @@ class Quantity:
             for c in self.children:
                 c.shift(name)
 
+    def copy(self, name):
+       copy = Quantity(name)
+       copy.shifts = self.shifts
+       copy.children = self.children
+       return copy
 
 pt_1 = Quantity("pt_1")
 pt_2 = Quantity("pt_2")
 m_vis = Quantity("m_vis")
 mt_1 = Quantity("mt_1")
+good_taus_mask = Quantity("good_taus_mask")
+Tau_pt = Quantity("Tau_pt")
+Tau_eta = Quantity("Tau_eta")
+Tau_dz = Quantity("Tau_dz")

--- a/code_generation/quantities.py
+++ b/code_generation/quantities.py
@@ -23,16 +23,31 @@ class Quantity:
         return copy
 
 
-pt_1 = Quantity("pt_1")
-pt_2 = Quantity("pt_2")
 m_vis = Quantity("m_vis")
 mt_1 = Quantity("mt_1")
 
 good_taus_mask = Quantity("good_taus_mask")
 Tau_pt = Quantity("Tau_pt")
 Tau_eta = Quantity("Tau_eta")
+Tau_phi = Quantity("Tau_phi")
+Tau_mass = Quantity("Tau_mass")
 Tau_dz = Quantity("Tau_dz")
+Tau_IDraw = Quantity("Tau_rawDeepTau2017v2p1VSjet")
 
 good_muons_mask = Quantity("good_muons_mask")
 Muon_pt = Quantity("Muon_pt")
 Muon_eta = Quantity("Muon_eta")
+Muon_phi = Quantity("Muon_phi")
+Muon_mass = Quantity("Muon_mass")
+Muon_iso = Quantity("Muon_pfRelIso04_all")
+
+ditaupair = Quantity("ditaupair")
+
+p4_1 = Quantity("p4_1")
+pt_1 = Quantity("pt_1")
+eta_1 = Quantity("eta_1")
+phi_1 = Quantity("phi_1")
+p4_2 = Quantity("p4_2")
+pt_2 = Quantity("pt_2")
+eta_2 = Quantity("eta_2")
+phi_2 = Quantity("phi_2")

--- a/config/config.py
+++ b/config/config.py
@@ -18,7 +18,7 @@ def build_config():
         ],
         "tau_id_idx": [4, 4, 1],
         "muon_id": "Muon_mediumId",
-        "muon_iso": "Muon_pfRelIso04_all",
+        # "muon_iso": "Muon_pfRelIso04_all",
         "muon_iso_cut": 0.15,
         "require_candidate": ["nTau", "nMuon"],
         "require_candidate_number": [1, 1],
@@ -26,7 +26,16 @@ def build_config():
 
     config = {"": copy.deepcopy(base_config), "_tauCutUp": copy.deepcopy(base_config)}
 
-    config["producers"] = ["MetFilter", "GoodTaus", "GoodMuons"]
+    config["producers"] = [
+        "MetFilter",
+        "GoodTaus",
+        "GoodMuons",
+        "MTPairSelection",
+        "GoodMTPairFilter",
+        "LVMu1",
+        "LVTau2",
+        "DiTauPairQuantities",
+    ]
 
     config["_tauCutUp"]["min_tau_pt"] = 31.0
     config["_tauCutUp"]["shiftbase"] = ["TauPtCut"]

--- a/config/config.py
+++ b/config/config.py
@@ -5,14 +5,17 @@ import code_generation.producer as p
 
 def build_config():
     base_config = {
-        "ptcut": 2.0,
-        "etacut": 1.0,
+        "ptcut": 30.0,
+        "etacut": 2.3,
+        "dzcut": 0.2,
         "met_filters": ["Flag_goodVertices", "Flag_METFilters"],
+        "tau_id": ["Tau_idDeepTau2017v2p1VSjet", "Tau_idDeepTau2017v2p1VSe", "Tau_idDeepTau2017v2p1VSmu"],
+        "tau_id_idx": [4, 4, 1]
     }
 
     config = {"": copy.deepcopy(base_config), "_tauEsUp": copy.deepcopy(base_config)}
 
-    config["producers"] = ["MetFilter"]
+    config["producers"] = ["MetFilter", "GoodTaus"]
 
     config["_tauEsUp"]["ptcut"] = 2.1
     # write some modifier tools for creating shifts. Should these automatically determine producers that consume params and shift these?

--- a/config/config.py
+++ b/config/config.py
@@ -28,7 +28,7 @@ def build_config():
 
     config["producers"] = ["MetFilter", "GoodTaus", "GoodMuons"]
 
-    config["_tauCutUp"]["ptcut"] = 2.1
+    config["_tauCutUp"]["min_tau_pt"] = 31.0
     config["_tauCutUp"]["shiftbase"] = ["TauPtCut"]
     # write some modifier tools for creating shifts. Should these automatically determine producers that consume params and shift these?
     # Or simply add an explicit command to the modifier tool to shift a producer

--- a/config/config.py
+++ b/config/config.py
@@ -5,17 +5,28 @@ import code_generation.producer as p
 
 def build_config():
     base_config = {
-        "ptcut": 30.0,
-        "etacut": 2.3,
-        "dzcut": 0.2,
+        "min_tau_pt": 30.0,
+        "max_tau_eta": 2.3,
+        "max_tau_dz": 0.2,
+        "min_muon_pt": 23.0,
+        "max_muon_eta": 2.5,
         "met_filters": ["Flag_goodVertices", "Flag_METFilters"],
-        "tau_id": ["Tau_idDeepTau2017v2p1VSjet", "Tau_idDeepTau2017v2p1VSe", "Tau_idDeepTau2017v2p1VSmu"],
-        "tau_id_idx": [4, 4, 1]
+        "tau_id": [
+            "Tau_idDeepTau2017v2p1VSjet",
+            "Tau_idDeepTau2017v2p1VSe",
+            "Tau_idDeepTau2017v2p1VSmu",
+        ],
+        "tau_id_idx": [4, 4, 1],
+        "muon_id": "Muon_mediumId",
+        "muon_iso": "Muon_pfRelIso04_all",
+        "muon_iso_cut": 0.15,
+        "require_candidate": ["nTau", "nMuon"],
+        "require_candidate_number": [1, 1],
     }
 
     config = {"": copy.deepcopy(base_config), "_tauCutUp": copy.deepcopy(base_config)}
 
-    config["producers"] = ["MetFilter", "GoodTaus"]
+    config["producers"] = ["MetFilter", "GoodTaus", "GoodMuons"]
 
     config["_tauCutUp"]["ptcut"] = 2.1
     config["_tauCutUp"]["shiftbase"] = ["TauPtCut"]

--- a/config/config.py
+++ b/config/config.py
@@ -13,11 +13,12 @@ def build_config():
         "tau_id_idx": [4, 4, 1]
     }
 
-    config = {"": copy.deepcopy(base_config), "_tauEsUp": copy.deepcopy(base_config)}
+    config = {"": copy.deepcopy(base_config), "_tauCutUp": copy.deepcopy(base_config)}
 
     config["producers"] = ["MetFilter", "GoodTaus"]
 
-    config["_tauEsUp"]["ptcut"] = 2.1
+    config["_tauCutUp"]["ptcut"] = 2.1
+    config["_tauCutUp"]["shiftbase"] = ["TauPtCut"]
     # write some modifier tools for creating shifts. Should these automatically determine producers that consume params and shift these?
     # Or simply add an explicit command to the modifier tool to shift a producer
     # AddShift(config, "_tauEsDown", dict)

--- a/generate.py
+++ b/generate.py
@@ -44,8 +44,6 @@ for sample_group in sample_groups:
     config = analysis.build_config()
     # modify config according to args
     # ...
-    # process shifts
-    # ...
     # fill code template and write executable
     with open(args.template, "r") as template_file:
         template = template_file.read()

--- a/generate.py
+++ b/generate.py
@@ -43,6 +43,10 @@ for sample_group in sample_groups:
     analysis = importlib.import_module("config." + args.analysis)
     config = analysis.build_config()
     # modify config according to args
+    # ...
+    # process shifts
+    # ...
+    # fill code template and write executable
     with open(args.template, "r") as template_file:
         template = template_file.read()
     template = fill_template(template, config)

--- a/lorentzvectors.hxx
+++ b/lorentzvectors.hxx
@@ -25,13 +25,6 @@ namespace lorentzvectors {
 /// \returns a new dataframe, which contains the new lorentz vector
 auto buildparticle(auto df, const std::vector<std::string> quantities,
                    const std::string outputname, const int &position) {
-    // std::vector<std::string> cols;
-    // cols.push_back(particle + "_pt");
-    // cols.push_back(particle + "_eta");
-    // cols.push_back(particle + "_phi");
-    // cols.push_back(particle + "_mass");
-    // const auto outputcol = "p4_" + std::to_string(position+1);
-    std::cout << outputname << std::endl;
     auto df1 = df.Define(
         outputname,
         [position](const ROOT::RVec<int> &pair, const ROOT::RVec<float> &pts,

--- a/lorentzvectors.hxx
+++ b/lorentzvectors.hxx
@@ -31,6 +31,7 @@ auto buildparticle(auto df, const std::vector<std::string> quantities,
     // cols.push_back(particle + "_phi");
     // cols.push_back(particle + "_mass");
     // const auto outputcol = "p4_" + std::to_string(position+1);
+    std::cout << outputname << std::endl;
     auto df1 = df.Define(
         outputname,
         [position](const ROOT::RVec<int> &pair, const ROOT::RVec<float> &pts,
@@ -53,6 +54,12 @@ auto buildparticle(auto df, const std::vector<std::string> quantities,
         },
         quantities);
     return df1;
+}
+
+auto build(auto df, const std::vector<std::string> &obj_quantities, const int pairindex, const std::string &obj_p4_name){
+    for (auto i : obj_quantities)
+        Logger::get("lorentzvectors")->debug("Used object quantities {}", i);
+    return lorentzvectors::buildparticle(df, obj_quantities, obj_p4_name, pairindex);
 }
 
 /// namespace used for mutau lorentzvectors

--- a/lorentzvectors.hxx
+++ b/lorentzvectors.hxx
@@ -56,10 +56,12 @@ auto buildparticle(auto df, const std::vector<std::string> quantities,
     return df1;
 }
 
-auto build(auto df, const std::vector<std::string> &obj_quantities, const int pairindex, const std::string &obj_p4_name){
+auto build(auto df, const std::vector<std::string> &obj_quantities,
+           const int pairindex, const std::string &obj_p4_name) {
     for (auto i : obj_quantities)
         Logger::get("lorentzvectors")->debug("Used object quantities {}", i);
-    return lorentzvectors::buildparticle(df, obj_quantities, obj_p4_name, pairindex);
+    return lorentzvectors::buildparticle(df, obj_quantities, obj_p4_name,
+                                         pairindex);
 }
 
 /// namespace used for mutau lorentzvectors

--- a/pairselection.hxx
+++ b/pairselection.hxx
@@ -209,13 +209,11 @@ auto PairSelectionAlgo() {
 ///  TODO add documentation here
 ///
 /// \returns a dataframe containing the new pairname column
-auto PairSelection(auto df, const std::string taumask,
-                   const std::string muonmask, const std::string pairname,
-                   const std::vector<std::string> pairvariables) {
+auto PairSelection(auto df, const std::vector<std::string> input_vector,
+                   const std::string pairname) {
     Logger::get("PairSelection")->debug("Setting up mutau pair building");
     auto df1 = df.Define(pairname, pairselection::mutau::PairSelectionAlgo(),
-                         {"Tau_pt", "Tau_rawDeepTau2017v2p1VSjet", "Muon_pt",
-                          "Muon_pfRelIso04_all", taumask, muonmask});
+                         input_vector);
     return df1;
 }
 

--- a/quantities.hxx
+++ b/quantities.hxx
@@ -73,12 +73,13 @@ auto m_vis(auto df, std::vector<std::string> varSet,
            const std::string &outputname, const std::string &inputvectors) {
     varSet.push_back(outputname);
     // build visible mass from the two particles
-    return df.Define("m_vis",
-                     [](const ROOT::Math::PtEtaPhiMVector &p4_1,
-                        const ROOT::Math::PtEtaPhiMVector &p4_2) {
-                         auto const dileptonsystem = p4_1 + p4_2;
-                         return dileptonsystem.mass();
-                     },
-                     inputvectors);
+    return df.Define(
+        "m_vis",
+        [](const ROOT::Math::PtEtaPhiMVector &p4_1,
+           const ROOT::Math::PtEtaPhiMVector &p4_2) {
+            auto const dileptonsystem = p4_1 + p4_2;
+            return dileptonsystem.mass();
+        },
+        inputvectors);
 }
 } // end namespace quantities

--- a/quantities.hxx
+++ b/quantities.hxx
@@ -70,11 +70,12 @@ auto phi(auto df, std::vector<std::string> varSet,
 /// \returns a dataframe with the new column
 
 auto m_vis(auto df, std::vector<std::string> varSet,
-           const std::string &outputname, const std::string &inputvectors) {
+           const std::string &outputname,
+           const std::vector<std::string> &inputvectors) {
     varSet.push_back(outputname);
     // build visible mass from the two particles
     return df.Define(
-        "m_vis",
+        outputname,
         [](const ROOT::Math::PtEtaPhiMVector &p4_1,
            const ROOT::Math::PtEtaPhiMVector &p4_2) {
             auto const dileptonsystem = p4_1 + p4_2;

--- a/quantities.hxx
+++ b/quantities.hxx
@@ -70,8 +70,7 @@ auto phi(auto df, std::vector<std::string> varSet,
 /// \returns a dataframe with the new column
 
 auto m_vis(auto df, std::vector<std::string> varSet,
-           const std::string &outputname, const std::string &inputvector1,
-           const std::string &inputvector2) {
+           const std::string &outputname, const std::string &inputvectors) {
     varSet.push_back(outputname);
     // build visible mass from the two particles
     return df.Define("m_vis",
@@ -80,6 +79,6 @@ auto m_vis(auto df, std::vector<std::string> varSet,
                          auto const dileptonsystem = p4_1 + p4_2;
                          return dileptonsystem.mass();
                      },
-                     {inputvector1, inputvector2});
+                     inputvectors);
 }
 } // end namespace quantities


### PR DESCRIPTION
Develops python backbone such that current example analysis.cxx can be reproduced.
In addition, an exemplary shift is introduced. Note, that filtering with shift needs better treatment.
Channel specific treatment not yet implemented.
Some cpp modules are modified to better fit a common structure.